### PR TITLE
fix `horizontal_scrolling()`'s incorrect assertions

### DIFF
--- a/app/src/androidTest/java/com/example/dogglers/HorizontalListTests.kt
+++ b/app/src/androidTest/java/com/example/dogglers/HorizontalListTests.kt
@@ -53,7 +53,8 @@ class HorizontalListTests : BaseTest() {
     fun `horizontal_scrolling`() {
         onView(withId(R.id.horizontal_recycler_view))
             .perform(swipeLeft())
-        onView(withText("Frankie")).check(matches(isDisplayed()))
+        Thread.sleep(1500)
+        onView(withText("Nox")).check(matches(isDisplayed()))
     }
 
     @Test


### PR DESCRIPTION
Please refer to issues #37 & #39.

The test `horizontal_scrolling()` does not give enough time for the list to be swiped left. As a result, the test will always fail even when the app is correctly implemented.

This fix adds a wait period (1.5 second) for the scrolling effect to come to a full stop, then check the name on the card on the screen i.e. "Nox".